### PR TITLE
[feat(auth)] : 인증 인프라 도입 및 로그인 · 회원가입· 헤더· 홈 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "talkit",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.13.2",
         "lucide-react": "^0.546.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -1760,6 +1761,12 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -1796,6 +1803,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1884,6 +1902,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -2019,6 +2050,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -2259,6 +2302,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -2272,6 +2324,20 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2293,6 +2359,51 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-toolkit": {
       "version": "1.40.0",
@@ -2696,6 +2807,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2711,6 +2842,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -2746,7 +2893,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2760,6 +2906,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -2835,6 +3018,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2845,11 +3040,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3172,6 +3393,15 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3207,6 +3437,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -3647,6 +3898,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,42 +1,43 @@
-import React from "react";
-import { Routes, Route, BrowserRouter, useLocation } from "react-router-dom";
-import LandingPage from "./component/LandingPage";
-import SaisaiHome from "./component/SaisaiHome";
-import Login from "./component/Login";
-import Signup from "./component/Signup";
-import Chattingpage from "./component/ChattingPage";
-import CommunityCreate from "./pages/community/CommunityCreate";
-import CommunityDetail from "./pages/community/CommunityDetail";
-import CommunityPage from "./pages/community/CommunityPage";
-import AIChattingPage from "./component/AIChattingPage";
-import MyPage from "./component/MyPage";
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { useLocation, Outlet } from 'react-router-dom';
 import Header from "./component/Header";
+import axiosInstance from "./api/axiosInstance";
+import { loginSuccess } from "./slices/loginSlice";
 
-const App = () => {
-
+function App() {
+  const dispatch = useDispatch();
   const location = useLocation();
-  
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      const token = localStorage.getItem('accessToken');
+      // 쿠키 방식이라면 토큰이 없어도 status 체크를 시도할 수 있습니다.
+      if (token) {
+        try {
+          const response = await axiosInstance.get('/api/users/me'); // 내 정보 가져오기 엔드포인트
+          dispatch(loginSuccess(response.data.user));
+        } catch (err) {
+          console.log("세션 만료 또는 유효하지 않은 토큰");
+          // 로그아웃 처리 등을 수행할 수 있습니다.
+        }
+      }
+    };
+    checkAuth();
+  }, [dispatch]);
+
+  // 헤더를 숨길 경로 설정
   const hideHeaderPaths = ["/", "/login", "/signup"];
   const shouldHideHeader = hideHeaderPaths.includes(location.pathname);
 
   return (
-    <main>
+    <div className="app-container">
       {!shouldHideHeader && <Header />}
-
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/signup" element={<Signup />} />
-        <Route path="/home" element={<SaisaiHome />} />
-        <Route path="/mypage" element={<MyPage />} />
-        <Route path="/chatting" element={<Chattingpage />} />
-        <Route path="/aichat" element={<AIChattingPage />} />
-        <Route path="/community" element={<CommunityPage />} />
-        <Route path="/community/create" element={<CommunityCreate />} />
-        <Route path="/community/detail" element={<CommunityDetail />} />
-      </Routes>
-    </main>
+      <main className="content">
+        <Outlet /> 
+      </main>
+    </div>
   );
-};
+}
 
 export default App;

--- a/src/api/axiosInstance.js
+++ b/src/api/axiosInstance.js
@@ -1,0 +1,91 @@
+import axios from 'axios';
+
+let isRefreshing = false;
+let refreshSubscribers = [];
+
+// 리덕스 스토어 주입을 위한 변수
+let store;
+export const injectStore = (_store) => {
+  store = _store;
+};
+
+const axiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_HOST,
+  withCredentials: true, // 쿠키 공유를 위해 필수
+});
+
+// 토큰 갱신 후 대기 중이던 요청들 재실행
+const onRefreshed = () => {
+  refreshSubscribers.forEach((callback) => callback());
+  refreshSubscribers = [];
+};
+
+// [요청 인터셉터]
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('accessToken'); 
+    if (token && !config.url.includes('/api/auth/reissue')) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+// [응답 인터셉터]
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (!error.response) {
+      console.error("네트워크 에러 또는 서버가 응답하지 않습니다.");
+      return Promise.reject(error);
+    }
+
+    const { status } = error.response;
+
+    // 401 Unauthorized 에러 발생 시
+    if (status === 401 && !originalRequest._retry) {
+      
+      if (isRefreshing) {
+        // 이미 재발급 중이면 대기열에 추가
+        return new Promise((resolve) => {
+          refreshSubscribers.push(() => resolve(axiosInstance(originalRequest)));
+        });
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        // 백엔드에 토큰 재발급 요청
+        await axiosInstance.post('/api/auth/reissue'); 
+        
+        isRefreshing = false;
+        onRefreshed(); // 대기열 요청들 처리
+        
+        return axiosInstance(originalRequest); // 현재 요청 재시도
+      } catch (refreshError) {
+        isRefreshing = false;
+        refreshSubscribers = []; // 실패 시 대기열 비움
+
+        console.error("세션이 만료되었습니다. 다시 로그인해주세요.");
+
+        if (store) {
+          // 순환 참조 방지를 위해 다이나믹 import 사용 가능성 고려
+          const { logout } = await import('../slices/loginSlice'); 
+          store.dispatch(logout());
+        }
+
+        // 로그인 페이지로 이동
+        window.location.href = '/login?expired=true'; 
+        return Promise.reject(refreshError);
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export default axiosInstance;

--- a/src/component/Header.jsx
+++ b/src/component/Header.jsx
@@ -1,10 +1,16 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
+import { useSelector, useDispatch } from "react-redux";
+import { logout } from "../slices/loginSlice";
+import axiosInstance from "../api/axiosInstance";
 
 const Header = () => {
   const navigate = useNavigate();
-  const [isCompact, setIsCompact] = useState(false);
+  const dispatch = useDispatch();
   const location = useLocation();
+  
+  const { isLoggedIn, userInfo } = useSelector((state) => state.login);
+  const [isCompact, setIsCompact] = useState(false);
   const currentPath = location.pathname;
 
   useEffect(() => {
@@ -20,46 +26,49 @@ const Header = () => {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
-  const userName = "김철수";
+  const userName = userInfo?.nickname || "사용자";
   const firstLetter = userName.charAt(0);
-  const isActive = (p) => currentPath === p;
   
+  const isActive = (p) => currentPath === p;
   const handleNavClick = (p) => navigate(p);
 
-  const handleLogout = () => alert("로그아웃 되었습니다.");
+  const handleLogout = async () => {
+    if (window.confirm("로그아웃 하시겠습니까?")) {
+      try {
+        await axiosInstance.post('/api/users/logout');
+      } catch (error) {
+        console.error("서버 로그아웃 오류:", error);
+      } finally {
+        dispatch(logout());
+        alert("로그아웃 되었습니다.");
+        navigate("/");
+      }
+    }
+  };
 
   return (
     <header
       className={`sticky top-0 z-[9999] bg-white overflow-hidden transition-all duration-500 ease-in-out ${
-        isCompact
-          ? "h-16 shadow-md border-b border-gray-200"
-          : "h-24 border-b-2 border-gray-100"
+        isCompact ? "h-16 shadow-md border-b border-gray-200" : "h-24 border-b-2 border-gray-100"
       }`}
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative h-full flex items-center justify-between">
-        {/* ✅ 로고 */}
-        <button
-            onClick={() => handleNavClick("/")}
-            className="text-xl font-bold text-gray-800"
-          >
-        <div className="flex items-center gap-2">
-          <div className="flex gap-1">
-            <div className="w-6 h-6 bg-primary rounded-full"></div>
-            <div className="w-6 h-6 bg-secondary rounded-full"></div>
-          </div>
-          
+        <button onClick={() => handleNavClick("/")} className="text-xl font-bold text-gray-800">
+          <div className="flex items-center gap-2">
+            <div className="flex gap-1">
+              <div className="w-6 h-6 bg-purple-500 rounded-full"></div>
+              <div className="w-6 h-6 bg-pink-500 rounded-full"></div>
+            </div>
             사이사이
-          
-        </div>
+          </div>
         </button>
 
-        {/* ✅ 네비게이션 */}
         <nav
           className="hidden md:flex gap-8 absolute left-1/2 -translate-x-1/2"
           style={{
-            top: isCompact ? "50%" : "75%",
+            top: "50%",
             transform: "translate(-50%, -50%)",
-            transition: "top 0.4s ease-in-out",
+            transition: "all 0.4s ease-in-out",
           }}
         >
           {[
@@ -71,9 +80,7 @@ const Header = () => {
               key={nav.path}
               onClick={() => handleNavClick(nav.path)}
               className={`text-lg transition-colors duration-200 ${
-                isActive(nav.path)
-                  ? "text-green-500 font-semibold"
-                  : "text-gray-500 hover:text-gray-900"
+                isActive(nav.path) ? "text-purple-600 font-semibold" : "text-gray-500 hover:text-gray-900"
               }`}
             >
               {nav.label}
@@ -81,23 +88,41 @@ const Header = () => {
           ))}
         </nav>
 
-        {/* ✅ 프로필 */}
         <div className="flex items-center gap-3">
-          <button
-            onClick={() => handleNavClick("/mypage")}
-            className="flex items-center gap-2 hover:opacity-80 transition-opacity"
-          >
-            <div className="w-10 h-10 bg-green-500 rounded-full flex items-center justify-center text-white font-semibold">
-              {firstLetter}
-            </div>
-            <span className="text-gray-800 font-medium">{userName}님</span>
-          </button>
-          <button
-            onClick={handleLogout}
-            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-900 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
-          >
-            로그아웃
-          </button>
+          {isLoggedIn ? (
+            <>
+              <button
+                onClick={() => handleNavClick("/mypage")}
+                className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+              >
+                <div className="w-10 h-10 bg-gradient-to-tr from-purple-500 to-pink-500 rounded-full flex items-center justify-center text-white font-semibold shadow-sm">
+                  {firstLetter}
+                </div>
+                <span className="text-gray-800 font-medium hidden sm:inline">{userName}님</span>
+              </button>
+              <button
+                onClick={handleLogout}
+                className="px-4 py-2 text-sm text-gray-600 hover:text-red-500 border border-gray-300 rounded-xl hover:bg-gray-50 transition-all"
+              >
+                로그아웃
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                onClick={() => handleNavClick("/login")}
+                className="px-5 py-2 text-sm font-medium text-gray-700 hover:text-purple-600 transition-colors"
+              >
+                로그인
+              </button>
+              <button
+                onClick={() => handleNavClick("/signup")}
+                className="px-5 py-2 text-sm font-medium text-white bg-gradient-to-r from-purple-600 to-pink-600 rounded-xl hover:opacity-90 transition-all shadow-md"
+              >
+                회원가입
+              </button>
+            </>
+          )}
         </div>
       </div>
     </header>

--- a/src/component/Login.jsx
+++ b/src/component/Login.jsx
@@ -1,7 +1,14 @@
 import React, { useState } from 'react';
 import { Mail, Lock, Eye, EyeOff } from 'lucide-react';
+import { useNavigate } from 'react-router-dom'; // 1. useNavigate 추가
+import { useDispatch } from 'react-redux';      // 2. useDispatch 추가
+import { loginSuccess } from '../slices/loginSlice'; // 3. 액션 임포트
+import axiosInstance from '../api/axiosInstance';   // 4. axios 인스턴스
 
-const Login = ({ onSwitchToSignup }) => {
+const Login = () => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
   const [formData, setFormData] = useState({ email: '', password: '' });
   const [showPassword, setShowPassword] = useState(false);
 
@@ -10,9 +17,44 @@ const Login = ({ onSwitchToSignup }) => {
     setFormData(prev => ({ ...prev, [name]: value }));
   };
 
-  const handleLogin = () => {
-    alert('로그인 처리 중...');
-    console.log('Login data:', formData);
+  const handleLogin = async () => {
+    try {
+      // 1. 로그인 요청
+      const response = await axiosInstance.post('/api/users/login', formData);
+      console.log("서버 응답 데이터:", response.data);
+
+      // 2. 데이터 구조 분해 할당 (응답 바디에는 user만 있음)
+      const { user } = response.data;
+      
+      // 3. 만약 백엔드가 헤더에 토큰을 실어 보냈다면 localStorage에 백업 (선택사항)
+      // 쿠키(httpOnly)를 사용한다면 이 과정이 없어도 axiosInstance가 쿠키를 자동으로 보냅니다.
+      const authHeader = response.headers['authorization'];
+      if (authHeader && authHeader.startsWith('Bearer ')) {
+          const token = authHeader.substring(7);
+          localStorage.setItem('accessToken', token);
+      }
+
+      // 4. 성공 판별 (바디에 user 정보가 왔다면 성공!)
+      if (user) {
+        // 리덕스 상태 업데이트 (유저 정보 저장)
+        dispatch(loginSuccess(user));
+        
+        alert('로그인에 성공했습니다!');
+        
+        // 홈 화면으로 이동
+        navigate('/home'); 
+      }
+    } catch (error) {
+      console.error("전체 에러 객체:", error);
+      
+      if (error.response) {
+          // 서버가 에러 코드를 반환한 경우 (401, 400 등)
+          alert(error.response.data?.message || "이메일 또는 비밀번호를 확인해주세요.");
+      } else {
+          // 네트워크 에러 (서버가 꺼져있거나 포트가 안 맞을 때)
+          alert("서버와 통신할 수 없습니다. 백엔드 포트(8080)와 실행 상태를 확인하세요.");
+      }
+    }
   };
 
   const handleSocialLogin = (provider) => {
@@ -22,7 +64,6 @@ const Login = ({ onSwitchToSignup }) => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 to-pink-50 flex items-center justify-center px-4">
       <div className="bg-white rounded-3xl shadow-2xl p-8 w-full max-w-md">
-        {/* 헤더 */}
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent mb-2">
             사이사이
@@ -30,8 +71,8 @@ const Login = ({ onSwitchToSignup }) => {
           <p className="text-gray-600">말잇는 사이트에 오신 것을 환영합니다</p>
         </div>
 
-        {/* 로그인 폼 */}
         <div className="space-y-6">
+          {/* 이메일 입력 */}
           <div className="relative">
             <label className="block text-sm font-medium text-gray-700 mb-2">이메일</label>
             <div className="relative">
@@ -43,11 +84,11 @@ const Login = ({ onSwitchToSignup }) => {
                 onChange={handleInputChange}
                 placeholder="이메일을 입력하세요"
                 className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all duration-200"
-                required
               />
             </div>
           </div>
 
+          {/* 비밀번호 입력 */}
           <div className="relative">
             <label className="block text-sm font-medium text-gray-700 mb-2">비밀번호</label>
             <div className="relative">
@@ -59,7 +100,6 @@ const Login = ({ onSwitchToSignup }) => {
                 onChange={handleInputChange}
                 placeholder="비밀번호를 입력하세요"
                 className="w-full pl-10 pr-12 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all duration-200"
-                required
               />
               <button
                 type="button"
@@ -80,7 +120,6 @@ const Login = ({ onSwitchToSignup }) => {
           </button>
         </div>
 
-        {/* 구분선 */}
         <div className="flex items-center my-6">
           <div className="flex-1 border-t border-gray-300"></div>
           <span className="px-4 text-sm text-gray-500">또는</span>
@@ -105,11 +144,10 @@ const Login = ({ onSwitchToSignup }) => {
           </button>
         </div>
 
-        {/* 회원가입 링크 */}
         <div className="text-center mt-6">
           <span className="text-gray-600">아직 계정이 없으신가요? </span>
           <button
-            onClick={onSwitchToSignup}
+            onClick={() => navigate('/signup')} // 5. useNavigate로 경로 이동
             className="text-purple-600 font-medium hover:text-purple-700 transition-colors duration-200"
           >
             회원가입

--- a/src/component/SaisaiHome.jsx
+++ b/src/component/SaisaiHome.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import axiosInstance from "../api/axiosInstance";
 import { Home, MessageCircle, BarChart3, User, Play, Search, Bell, Award, Calendar, Sparkles } from 'lucide-react';
 
 const SaisaiHome = () => {
@@ -11,9 +11,9 @@ const SaisaiHome = () => {
   useEffect(() => {
     const fetchStats = async () => {
       try {
-        const response = await axios.get('http://localhost:8080/api/stats/recent');
+        const response = await axiosInstance.get('/api/stats/recent');
         console.log("받아온 데이터: ",response.data)
-        setRecentStats(response.data); // 백엔드에서 받은 [ {...}, {...} ] 데이터를 저장
+        setRecentStats(response.data);
       } catch (error) {
         console.error("데이터 로딩 실패:", error);
       }

--- a/src/component/Signup.jsx
+++ b/src/component/Signup.jsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Mail, Lock, User, ChevronDown, Eye, EyeOff } from 'lucide-react';
+import axiosInstance from "../api/axiosInstance";
 
-const Signup = ({ onSwitchToLogin }) => {
+const Signup = () => {
+  const navigate = useNavigate();
   const [formData, setFormData] = useState({
     email: '', password: '', nickname: '', gender: '', birthYear: '', agreeTerms: false
   });
@@ -15,17 +18,29 @@ const Signup = ({ onSwitchToLogin }) => {
     }));
   };
 
-  const handleSignup = () => {
+  const handleSignup = async () => {
     if (!formData.agreeTerms) {
       alert('이용약관에 동의해주세요.');
       return;
     }
-    alert('회원가입 처리 중...');
-    console.log('Signup data:', formData);
-  };
+    try {
+      const response = await axiosInstance.post('/api/users/signup', {
+        email: formData.email,
+        password: formData.password,
+        nickname: formData.nickname,
+        gender: formData.gender,
+        birthYear: parseInt(formData.birthYear)
+      });
 
-  const handleSocialLogin = (provider) => {
-    alert(`${provider} 로그인 연동 준비중입니다!`);
+      if (response.status === 200 || response.status === 201) {
+        alert('회원가입이 완료되었습니다! 로그인 페이지로 이동합니다.');
+        navigate('/login'); // 성공 시 이동
+      }
+    } catch (error) {
+      console.error('회원가입 에러:', error);
+      const message = error.response?.data?.message || '회원가입 실패';
+      alert(message);
+    }
   };
 
   const currentYear = new Date().getFullYear();
@@ -199,7 +214,7 @@ const Signup = ({ onSwitchToLogin }) => {
           <div className="text-center mt-4">
             <span className="text-gray-600">이미 계정이 있으신가요? </span>
             <button
-              onClick={onSwitchToLogin}
+              onClick={() => navigate('/login')}
               className="text-purple-600 font-medium hover:text-purple-700 transition-colors duration-200"
             >
               로그인

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,13 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import store from './store';
+import { RouterProvider } from 'react-router-dom';
+import router from './routes/Router';
 import './index.css';
-import App from './App.jsx';
 
-createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </StrictMode>
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <Provider store={store}>
+    <RouterProvider router={router} />
+  </Provider>
 );

--- a/src/routes/AuthenticatedRoute.jsx
+++ b/src/routes/AuthenticatedRoute.jsx
@@ -1,0 +1,16 @@
+import { Navigate } from 'react-router-dom';
+
+const AuthenticatedRoute = ({ children }) => {
+  // 예시: 로컬 스토리지에 토큰이 있는지 확인
+  const token = localStorage.getItem('accessToken');
+  const isLoggedIn = !!token; // 토큰이 있으면 true
+
+  if (!isLoggedIn) {
+    alert("로그인이 필요한 페이지입니다.");
+    return <Navigate to="/api/users/login" replace />; // /unauthenticated 대신 /login으로 보냄
+  }
+
+  return children;
+};
+
+export default AuthenticatedRoute;

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -1,50 +1,101 @@
 import { createBrowserRouter } from 'react-router-dom';
-
+import App from '../App'; // App 컴포넌트 임포트 확인!
 import LandingPage from "../component/LandingPage";
 import SaisaiHome from "../component/SaisaiHome";
 import Login from "../component/Login";
 import Signup from "../component/Signup";
-import ChattingPage from "../component/ChattingPage";
+import ChattingPage from "../component/ChattingPage"; 
+import CommunityPage from "../pages/community/CommunityPage";
 import CommunityCreate from "../pages/community/CommunityCreate";
 import CommunityDetail from "../pages/community/CommunityDetail";
-import CommunityPage from "../pages/community/CommunityPage";
-import AIChattingPage from "../component/AIChattingPage";
 import MyPage from "../component/MyPage";
-import Header from "../component/Header";
+import AIChattingPage from "../component/AIChattingPage";
+import AuthenticatedRoute from "./AuthenticatedRoute";
 
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <LandingPage type="header" />,
-  },
-  {
-    path: '/community',
+    element: <App />,
     children: [
-        {
+      {
+        index: true,
+        element: <LandingPage />,
+      },
+      {
+        path: 'login',
+        element: <Login />,
+      },
+      {
+        path: 'signup',
+        element: <Signup />,
+      },
+      {
+        path: 'home',
+        element: (
+          <AuthenticatedRoute>
+            <SaisaiHome />
+          </AuthenticatedRoute>
+        ),
+      },
+      {
+        path: 'mypage',
+        element: (
+          <AuthenticatedRoute>
+            <MyPage />
+          </AuthenticatedRoute>
+        ),
+      },
+      {
+        path: 'chatting',
+        element: (
+          <AuthenticatedRoute>
+            <ChattingPage />
+          </AuthenticatedRoute>
+        ),
+      },
+      {
+        path: 'aichat',
+        element: (
+          <AuthenticatedRoute>
+            <AIChattingPage />
+          </AuthenticatedRoute>
+        ),
+      },
+      // 커뮤니티 그룹화
+      {
+        path: 'community',
+        children: [
+          {
             index: true,
             element: (
-            <AuthenticatedRoute>
-                <Refrigerator />
-            </AuthenticatedRoute>
+              <AuthenticatedRoute>
+                <CommunityPage />
+              </AuthenticatedRoute>
             ),
-        },
-        {
-            path: '',
+          },
+          {
+            path: 'create',
             element: (
-            <AuthenticatedRoute>
-                <Refrigerator />
-            </AuthenticatedRoute>
+              <AuthenticatedRoute>
+                <CommunityCreate />
+              </AuthenticatedRoute>
             ),
-        },
-        {
-            path: 'search',
+          },
+          {
+            path: 'detail',
             element: (
-            <AuthenticatedRoute>
-                <RefrigeratorSearch />
-            </AuthenticatedRoute>
+              <AuthenticatedRoute>
+                <CommunityDetail />
+              </AuthenticatedRoute>
             ),
-        },
+          },
+        ],
+      },
     ],
+  },
+  {
+    path: '*',
+    element: <LandingPage />, // 정의되지 않은 경로는 랜딩페이지로
   },
 ]);
 

--- a/src/slices/loginSlice.js
+++ b/src/slices/loginSlice.js
@@ -1,0 +1,29 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  isLoggedIn: !!localStorage.getItem('accessToken') || document.cookie.includes('accessToken'),
+  userInfo: localStorage.getItem('userInfo') 
+    ? JSON.parse(localStorage.getItem('userInfo')) 
+    : null,
+};
+
+const loginSlice = createSlice({
+  name: 'login',
+  initialState,
+  reducers: {
+    loginSuccess: (state, action) => {
+      state.isLoggedIn = true;
+      state.userInfo = action.payload;
+      localStorage.setItem('userInfo', JSON.stringify(action.payload));
+    },
+    logout: (state) => {
+      state.isLoggedIn = false;
+      state.userInfo = null;
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('userInfo');
+    },
+  },
+});
+
+export const { loginSuccess, logout } = loginSlice.actions;
+export default loginSlice.reducer;

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,8 @@
+import { configureStore } from '@reduxjs/toolkit';
+import loginReducer from './slices/loginSlice.js';
+
+export default configureStore({
+  reducer: {
+    login: loginReducer, 
+  },
+});


### PR DESCRIPTION
## 어떤 기능인가요?
> 인증(로그인/회원가입) 및 헤더/홈 화면 관련 기능을 수정
> 인증 인프라(axios 인터셉터, 스토어) 연동을 추가


## 작업 상세 내용
인증(로그인/회원가입) 및 인증 인프라(axios 인터셉터 · 토큰 재발급), 헤더/홈 UI 개선을 추가합니다. 리덕스 스토어와 연동하여 로그인 상태를 관리합니다.

## 변경 사항 (요약)
- `src/api/axiosInstance.js` — 인증 토큰 자동 갱신(인터셉터) 구현  
- `src/component/Login.jsx` — 로그인 폼 서버 연동 및 리덕스 반영  
- `src/component/Signup.jsx` — 회원가입 폼 서버 연동 및 유효성 처리  
- `src/component/Header.jsx` — 로그인/로그아웃 흐름 정리, 헤더 compact 동작 유지  
- `src/component/SaisaiHome.jsx` — 홈 데이터 로딩 및 UI 보강  
- `src/slices/loginSlice.js` — 로그인 슬라이스(상태/로컬스토리지 동기화)  
- `src/store.js` — Redux 스토어 설정  
- 라우터/앱 진입부: `src/routes/AuthenticatedRoute.jsx`, `src/routes/Router.jsx`, `src/main.jsx`, `src/App.jsx`  
- 기타: `.gitignore`, `package-lock.json`

## 상세 변경 내역
### `src/api/axiosInstance.js`
- 요청 인터셉터: `localStorage`의 `accessToken`을 `Authorization` 헤더에 자동 첨부
- 응답 인터셉터: 401 발생 시 `/api/auth/reissue`로 토큰 재발급 시도
  - 재발급 중인 요청은 큐잉 후 재실행
  - 재발급 실패 시 리덕스 `logout()` 디스패치(주입된 스토어 사용) 및 `/login?expired=true`로 리디렉트

### `src/component/Login.jsx`
- `handleLogin` 구현: `/api/users/login` POST 요청
- 성공 시 응답의 `user`로 `loginSuccess` 디스패치, 응답 헤더의 Bearer 토큰이 있으면 `localStorage`에 저장
- 에러(서버/네트워크)별 사용자 알림 처리

### `src/component/Signup.jsx`
- `handleSignup` 구현: `/api/users/signup` 호출 및 입력 유효성/약관 확인 후 제출
- 성공 시 리디렉션(예: `/login`) 처리, 실패 시 에러 알림

### `src/slices/loginSlice.js`
- `loginSuccess`, `logout` 리듀서 구현
- 초기 상태를 `localStorage`에서 로드하여 세션 유지 지원
- 로그인시 `userInfo` 저장, 로그아웃 시 정리

### `src/component/Header.jsx`
- 스크롤 기반 compact 모드 유지 (스크롤 >50px 축소 등)
- 로그인 상태에 따른 아바타/닉네임 표시 및 로그아웃 흐름 정리
- 로그아웃: 확인창 → `/api/users/logout` 호출 시도 → 결과와 상관없이 로컬 `logout()` 디스패치 및 홈으로 이동

### 기타 (라우터/스토어/앱)
- 인증 전용 라우트(`AuthenticatedRoute`) 추가
- `src/main.jsx`/`src/App.jsx`에서 프로바이더·스토어 연결 반영

