### PR TITLE
[ feat ] : 커뮤니티 메인 상단 실시간 통계 수치 연동

### DIFF
--- a/src/component/community/CommunityListPage.jsx
+++ b/src/component/community/CommunityListPage.jsx
@@ -9,12 +9,30 @@ import CommunitySearchBar from './CommunitySearchBar';
 const CommunityListPage = () => {
   const [posts, setPosts] = useState([]);
   const [loading, setLoading] = useState(true);
+
+  const [stats, setStats] = useState({
+    totalPostCount: 0,
+    totalCommentCount: 0,
+    activeUserCount: 0
+  });
+
   const [selectedCategory, setSelectedCategory] = useState('전체');
   const [viewMode, setViewMode] = useState('grid');
   const [isTopButtonVisible, setIsTopButtonVisible] = useState(false);
   const [searchCondition, setSearchCondition] = useState({ searchType: 'TITLE', keyword: '' });
   
   const navigate = useNavigate();
+
+  const fetchStats = async () => {
+    try {
+      const response = await axiosInstance.get('/api/community/stats');
+      if (response.data && response.data.data) {
+        setStats(response.data.data);
+      }
+    } catch (error) {
+      console.error("통계 데이터 로드 실패:", error);
+    }
+  }
 
   const fetchCommunityPosts = useCallback(async (condition) => {
     try {
@@ -45,12 +63,15 @@ const CommunityListPage = () => {
 
   useEffect(() => {
     fetchCommunityPosts(searchCondition);
+    fetchStats();
+
     const handleScroll = () => setIsTopButtonVisible(window.scrollY > 100);
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, [fetchCommunityPosts, searchCondition]);
-  const categories = ['전체', '대화후기', '일상공유', '질문하기', '꿀팁공유', '감사인사'];
   
+
+  const categories = ['전체', '대화후기', '일상공유', '질문하기', '꿀팁공유', '감사인사'];
   const filteredPosts = posts.filter(post => {
     if (selectedCategory === '전체') return true;
     if (selectedCategory === '인기글') return post.likeCount >= 20;
@@ -72,15 +93,21 @@ return (
           {/* 통계 수치 영역 */}
           <div className="flex flex-wrap justify-center gap-8 sm:gap-16 mb-12">
             <div>
-              <div className="text-3xl sm:text-4xl font-bold text-green-400">{posts.length}</div>
+              <div className="text-3xl sm:text-4xl font-bold text-green-400">
+                {(stats.totalPostCount || 0).toLocaleString()}
+              </div>
               <div className="text-sm text-gray-500 mt-1">게시글</div>
             </div>
             <div>
-              <div className="text-3xl sm:text-4xl font-bold text-green-400">3,829</div>
+              <div className="text-3xl sm:text-4xl font-bold text-green-400">
+                {(stats.totalCommentCount || 0).toLocaleString()}
+              </div>
               <div className="text-sm text-gray-500 mt-1">댓글</div>
             </div>
             <div>
-              <div className="text-3xl sm:text-4xl font-bold text-green-400">856</div>
+              <div className="text-3xl sm:text-4xl font-bold text-green-400">
+                {(stats.activeUserCount || 0).toLocaleString()}
+              </div>
               <div className="text-sm text-gray-500 mt-1">활동 멤버</div>
             </div>
           </div>

--- a/src/component/community/CommunitySearchBar.jsx
+++ b/src/component/community/CommunitySearchBar.jsx
@@ -7,7 +7,7 @@ const CommunitySearchBar = ({ onSearch }) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef(null);
 
-  const typeOptions = [
+  const options = [
     { value: '', label: '전체' },
     { value: 'TITLE', label: '제목' },
     { value: 'CONTENT', label: '내용' },
@@ -15,7 +15,7 @@ const CommunitySearchBar = ({ onSearch }) => {
     { value: 'TAG', label: '태그' },
   ];
 
-  const currentLabel = typeOptions.find(opt => opt.value === searchType)?.label;
+  const currentLabel = options.find(opt => opt.value === searchType)?.label;
 
   const handleSelect = (value) => {
     setSearchType(value);


### PR DESCRIPTION
## 💡 개요
백엔드 통계 API를 연동하여 커뮤니티 메인 페이지의 수치를 실시간 데이터로 교체했습니다.

## 🛠️ 주요 작업 내용
- **API 연동**: `axiosInstance`를 활용해 `/api/community/stats` 데이터 호출 로직 추가
- **상태 관리**: `stats` state를 추가하여 서버로부터 받은 통계 수치 저장
- **UI 반영**: 
  - 하드코딩된 더미 데이터를 실제 서버 데이터로 교체
  - `toLocaleString()`을 적용하여 숫자 세 자리마다 콤마(,) 포맷팅 추가

## ✅ 테스트 결과
- 페이지 로드 시 실시간 통계 데이터가 정상적으로 화면에 출력되는 것을 확인했습니다.
<img width="100%" height="100%" alt="스크린샷 2026-02-12 202428" src="https://github.com/user-attachments/assets/4ee50d58-342d-46be-9a65-52a6b3015f4d" />
