### PR TITLE
[feat(UserChat)]: 채팅 입력 제한 및 대화 연장/종료 모달 로직 개선

### DIFF
--- a/src/component/ChattingPage.jsx
+++ b/src/component/ChattingPage.jsx
@@ -5,19 +5,24 @@ import SockJS from "sockjs-client";
 import TopicSelectionModal from "./modal/TopicSelectionModal";
 import ChattingEndModal from "./modal/ChattingEndModal";
 import CreateChatRoom from "./modal/CreateChatRoom";
+import ChattingExtendModal from "./modal/ChattingExtendModal";
+import ChattingExtendWaitingModal from "./modal/ChattingExtendWaitingModal.jsx";
 
 const Chattingpage = () => {
   const [showChatEnd, setShowChatEnd] = useState(false);
   const [messages, setMessages] = useState([]);
-  const [turnCount, setTurnCount] = useState(0);
-  const [maxTurns] = useState(40); //메세지 전체 개수 제한
+  const [setTurnCount] = useState(0);
+  const [maxTurns, setMaxTurns] = useState(3); //메세지 전체 개수 제한
   const [myContinuousCount, setMyContinuousCount] = useState(0); //연속 전송 회수
   const [inputText, setInputText] = useState("");
   const [showTopicModal, setShowTopicModal] = useState(true);
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showExtendModal, setShowExtendModal] = useState(false);
+  const [showExtendWaitingModal, setShowExtendWaitingModal] = useState(false);
   const [dbTopics, setDbTopics] = useState([]);
 
   const isMounted = useRef(false);
+  const userIdRef = useRef(null);
 
   // --- 추가된 실시간 통신 상태 ---
   const [roomId, setRoomId] = useState(null);
@@ -48,18 +53,20 @@ const Chattingpage = () => {
       return;
     }
 
-    console.log(`${room.topic} 방으로 입장합니다. ID: ${room.roomId}, UserID: ${currentUserId}`);
+    console.log(
+      `${room.topic} 방으로 입장합니다. ID: ${room.roomId}, UserID: ${currentUserId}`,
+    );
 
     setUserId(currentUserId);
     setRoomId(room.roomId);
+    setMaxTurns(room.maxTurns);
     setIsMatched(true);
     setShowTopicModal(false);
 
-    disconnect(); 
+    disconnect();
     connect(room.roomId);
     loadHistory(room.roomId, currentUserId);
   };
-
 
   // 페이지 로드 시 및 모달이 켜질 때 호출
   useEffect(() => {
@@ -77,7 +84,7 @@ const Chattingpage = () => {
         stompClient.current.deactivate();
       }
     };
-  }, []); 
+  }, []);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -87,6 +94,10 @@ const Chattingpage = () => {
   useEffect(() => {
     scrollToBottom();
   }, [messages]);
+
+  useEffect(() => {
+  userIdRef.current = userId;
+}, [userId]);
 
   const initMatch = async (selectedTopic) => {
     try {
@@ -107,6 +118,7 @@ const Chattingpage = () => {
 
       if (data && data.roomId) {
         setRoomId(data.roomId);
+        setMaxTurns(data.maxTurns);
         setIsMatched(data.matched);
         setUserId(data.userId);
 
@@ -118,7 +130,7 @@ const Chattingpage = () => {
     }
   };
 
-  const loadHistory = async (id,currentUserId) => {
+  const loadHistory = async (id, currentUserId) => {
     if (!id) return;
 
     try {
@@ -134,13 +146,11 @@ const Chattingpage = () => {
       for (let i = historyArray.length - 1; i >= 0; i--) {
         if (historyArray[i].senderId === Number(activeId)) {
           count++;
-          
         } else {
           break;
         }
       }
       setMyContinuousCount(count);
-
     } catch (error) {
       console.error("History 로드 에러:", error);
       setMessages([]); // 에러 시 빈 배열로 초기화
@@ -159,7 +169,7 @@ const Chattingpage = () => {
 
   const handleConfirmCreate = (newTopic) => {
     setShowCreateModal(false);
-    initMatch(newTopic); 
+    initMatch(newTopic);
   };
 
   const connect = (id) => {
@@ -169,21 +179,53 @@ const Chattingpage = () => {
       webSocketFactory: () => socket,
       onConnect: () => {
         stompClient.current.subscribe(`/sub/room/${id}`, (frame) => {
+          
           if (frame.body === "MATCH_COMPLETE") {
+            console.log("매칭 완료 신호 수신 (String)");
             setIsMatched(true);
             return;
           } else {
             try {
-              const newMessage = JSON.parse(frame.body);
+              const data = JSON.parse(frame.body);
 
-              if (newMessage.type === "CHAT_END") {
+              if (
+                data.status === "MATCH_COMPLETE" ||
+                data.type === "MATCH_COMPLETE"
+              ) {
+                console.log("매칭 완료 신호 수신 (JSON)");
+                setIsMatched(true);
+                return;
+              }
+
+              if (data.type === "EXTEND_REJECTED") {
+                setShowExtendWaitingModal(false); 
+                setShowExtendModal(false); 
                 setShowChatEnd(true);
                 return;
               }
-              setMessages((prev) => [...prev, newMessage]);
+
+              if (data.type === "EXTEND_COMPLETE") {
+                setShowExtendWaitingModal(false); // 1. 대기 모달 닫기
+                if (data.newMaxTurns) {
+                  setMaxTurns(data.newMaxTurns);
+                }
+                return;
+              }
+
+              if (data.type === "CHAT_END") {
+                const currentMax = data.maxTurns || maxTurns;
+                if (currentMax > 3) {
+                  setShowExtendModal(false);
+                  setShowChatEnd(true); // 바로 최종 종료(감정 선택) 모달 오픈
+                } else {
+                  setShowExtendModal(true); // 아직 연장 전이면 연장 제안 모달 오픈
+                }
+                return;
+              }
+              setMessages((prev) => [...prev, data]);
               setTurnCount((prev) => prev + 1);
 
-              if (newMessage.senderId !== Number(userId)) {
+              if (Number(data.senderId) !== Number(userIdRef.current)) {
                 setMyContinuousCount(0);
               }
             } catch (e) {
@@ -193,12 +235,12 @@ const Chattingpage = () => {
         });
       },
       onStompError: (frame) => {
-        console.error('Broker reported error: ' + frame.headers['message']);
-            console.error('Additional details: ' + frame.body);
+        console.error("Broker reported error: " + frame.headers["message"]);
+        console.error("Additional details: " + frame.body);
       },
       onWebSocketClose: (event) => {
-      console.log("⚠️ 닫힘 코드:", event.code, event.reason);
-    }
+        console.log("⚠️ 닫힘 코드:", event.code, event.reason);
+      },
     });
     stompClient.current.activate();
   };
@@ -208,51 +250,61 @@ const Chattingpage = () => {
   };
 
   const handleSendMessage = () => {
-    if (
-      inputText.trim() &&
-      isMatched &&
-      stompClient.current &&
-      userId &&
-      myContinuousCount < 3
-    ) {
+    const trimmedText = inputText.trim();
+    if (!trimmedText || !isMatched || !stompClient.current || !userId) return;
+    if (myContinuousCount >= 3) {
+      alert("상대방의 대답을 기다려야 합니다."); // 방어 코드
+    return;
+  }
+    
       stompClient.current.publish({
         destination: `/pub/room/${roomId}/message`,
         body: JSON.stringify({ message: inputText }),
         headers: { userId: String(userId) },
       });
-      setMyContinuousCount((prev) => prev + 1);
+      setMyContinuousCount((prev) => {
+      const newCount = prev + 1;
+      return newCount;
+    });
       setInputText("");
+    
+  };
 
-      // 전체 종료 체크
-      if (turnCount + 1 >= maxTurns) {
-        setTimeout(() => setShowChatEnd(true), 1500);
-      }
+  const handleExtendChat = () => {
+    setShowExtendModal(false);
+    setShowExtendWaitingModal(true);
 
-      setInputText("");
-
-      //대화 종료 트리거 체크
-      if (turnCount >= maxTurns) {
-        setTimeout(() => setShowChatEnd(true), 1500);
-      }
+    if (stompClient.current && roomId && userId) {
+      stompClient.current.publish({
+        destination: `/pub/room/${roomId}/extend`, // 컨트롤러의 주소
+        headers: { userId: String(userId) },
+        // 별도의 바디 데이터가 없어도 헤더의 userId로 서버에서 처리 가능합니다.
+        body: JSON.stringify({ action: "EXTEND" }),
+      });
+      console.log(
+        `서버로 연장 요청을 보냈습니다. Room: ${roomId}, User: ${userId}`,
+      );
     }
   };
 
+  const isInputDisabled = !isMatched || myContinuousCount >= 3;
   let placeholderText = "매칭 대기 중...";
   if (isMatched) {
-  placeholderText = myContinuousCount >= 3 
-    ? "상대방의 대답을 기다려주세요." 
-    : "메시지를 입력해주세요...";
-}
+    placeholderText =
+      myContinuousCount >= 3
+        ? "상대방의 대답을 기다려주세요."
+        : "메시지를 입력해주세요...";
+  }
 
   return (
     <div className="w-full h-screen bg-gray-50 flex items-center justify-center relative">
       <div
-        className={`w-full h-full max-w-4xl mx-auto bg-white flex flex-col transition-all duration-300 ${showChatEnd ? "blur-sm" : ""}`}
+        className={`w-full h-full max-w-4xl mx-auto bg-white flex flex-col transition-all duration-300 
+          ${showChatEnd || showExtendModal ? "blur-sm" : ""}`}
       >
         {/* Header */}
         <div className="flex items-center justify-between p-3 sm:p-4 border-b bg-white">
           <div className="flex items-center gap-2 sm:gap-3">
-            
             <button className="p-1.5 sm:p-2 hover:bg-gray-100 rounded-lg">
               <X className="w-5 h-5 sm:w-6 sm:h-6 text-gray-600" />
             </button>
@@ -274,7 +326,7 @@ const Chattingpage = () => {
               {Array.isArray(messages) &&
                 messages.map((msg) => (
                   <div key={msg.cmid}>
-                    {msg.senderId === Number(userId) ?  (
+                    {msg.senderId === Number(userId) ? (
                       /* 내가 보낸 메시지 UI (오른쪽) */
                       <div className="flex justify-end mb-4">
                         <div className="flex flex-col items-end">
@@ -291,7 +343,7 @@ const Chattingpage = () => {
                           </p>
                         </div>
                       </div>
-                    ): (
+                    ) : (
                       /* 상대방 UI (왼쪽) */
                       <div className="flex gap-2 sm:gap-3 mb-4">
                         <div className="flex-shrink-0">
@@ -332,12 +384,13 @@ const Chattingpage = () => {
                   onChange={(e) => setInputText(e.target.value)}
                   onKeyPress={(e) => e.key === "Enter" && handleSendMessage()}
                   placeholder={placeholderText}
-                  disabled={!isMatched || myContinuousCount >= 3}
+                  disabled={isInputDisabled}
                   className={`flex-1 px-3 sm:px-4 py-2.5 sm:py-3 border rounded-lg text-sm sm:text-base focus:outline-none focus:ring-2 focus:ring-blue-500 
-                    ${isMatched ? "" : "bg-gray-100 cursor-not-allowed"}`}
+                    ${!isInputDisabled ? "bg-white cursor-text" : "bg-gray-100 cursor-not-allowed"}`}
                 />
                 <button
                   onClick={handleSendMessage}
+                  disabled={isInputDisabled}
                   className="px-4 sm:px-6 py-2.5 sm:py-3 bg-green-400 text-white rounded-lg hover:bg-green-500 transition-colors"
                 >
                   <Send className="w-5 h-5 sm:w-6 sm:h-6" />
@@ -362,6 +415,27 @@ const Chattingpage = () => {
         isOpen={showCreateModal}
         onClose={() => setShowCreateModal(false)}
         onCreate={handleConfirmCreate}
+      />
+
+      <ChattingExtendModal
+        isOpen={showExtendModal}
+        onClose={() => {
+          stompClient.current.publish({
+            destination: `/pub/room/${roomId}/reject`,
+            headers: { userId: String(userId) },
+          });
+          setShowExtendModal(false);
+          setShowChatEnd(true); // '종료하기' 누르면 감정 선택 모달 오픈
+        }}
+        onExtend={handleExtendChat}
+      />
+
+      <ChattingExtendWaitingModal
+        isOpen={showExtendWaitingModal}
+        onCancel={() => {
+          setShowExtendWaitingModal(false);
+          setShowChatEnd(true);
+        }}
       />
 
       <ChattingEndModal

--- a/src/component/ChattingPage.jsx
+++ b/src/component/ChattingPage.jsx
@@ -11,7 +11,7 @@ import ChattingExtendWaitingModal from "./modal/ChattingExtendWaitingModal.jsx";
 const Chattingpage = () => {
   const [showChatEnd, setShowChatEnd] = useState(false);
   const [messages, setMessages] = useState([]);
-  const [setTurnCount] = useState(0);
+  const [turnCount, setTurnCount] = useState(0);
   const [maxTurns, setMaxTurns] = useState(3); //메세지 전체 개수 제한
   const [myContinuousCount, setMyContinuousCount] = useState(0); //연속 전송 회수
   const [inputText, setInputText] = useState("");

--- a/src/component/modal/ChattingEndModal.jsx
+++ b/src/component/modal/ChattingEndModal.jsx
@@ -58,7 +58,7 @@ const ChattingEndModal = ({ isOpen, onClose }) => {
             }}
             className="flex-1 px-4 py-2.5 sm:py-3 rounded-lg text-sm sm:text-base font-medium text-white bg-blue-500 hover:bg-blue-600 transition-colors"
           >
-            다음
+            종료
           </button>
         </div>
       </div>

--- a/src/component/modal/ChattingExtendModal.jsx
+++ b/src/component/modal/ChattingExtendModal.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+const ChattingExtendModal = ({ isOpen, onClose, onExtend }) => {
+
+
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-2xl p-6 sm:p-8 max-w-md w-full shadow-xl">
+        <h2 className="text-xl sm:text-2xl font-bold text-center mb-3 text-gray-800">
+          대화가 종료되었어요! 🤗
+        </h2>
+        <p className="text-center text-gray-600 mb-2 text-sm sm:text-base">
+          대화가 즐거우셨나요?
+        </p>
+        <p className="text-center text-gray-500 mb-6 text-xs sm:text-sm">
+          대화를 더 연장하시겠습니까? <br/>상대방도 연장을 원할 경우 25턴 연장됩니다.
+        </p>
+        {/* 하단 액션 버튼 */}
+        <div className="flex gap-2 sm:gap-3">
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-2.5 sm:py-3 rounded-lg text-sm sm:text-base font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 transition-colors"
+          >
+            종료하기
+          </button>
+          <button
+            onClick={() => onExtend()} className="flex-1 px-4 py-2.5 sm:py-3 rounded-lg text-sm sm:text-base font-medium text-white bg-blue-500 hover:bg-blue-600 transition-colors">
+            연장하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChattingExtendModal;

--- a/src/component/modal/ChattingExtendWaitingModal.jsx
+++ b/src/component/modal/ChattingExtendWaitingModal.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+const ChattingWaitModal = ({ isOpen, onCancel }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-2xl p-6 sm:p-8 max-w-md w-full shadow-xl">
+        {/* 로딩 애니메이션 아이콘 */}
+        <div className="flex justify-center mb-6">
+          <div className="relative flex items-center justify-center">
+            <div className="animate-ping absolute h-12 w-12 rounded-full bg-blue-400 opacity-20"></div>
+            <div className="relative rounded-full h-12 w-12 bg-blue-500 flex items-center justify-center text-white text-2xl">
+              ⌛
+            </div>
+          </div>
+        </div>
+
+        <h2 className="text-xl sm:text-2xl font-bold text-center mb-3 text-gray-800">
+          상대방의 응답을 기다리는 중...
+        </h2>
+        
+        <p className="text-center text-gray-600 mb-2 text-sm sm:text-base">
+          잠시만 기다려 주세요!
+        </p>
+        
+        <p className="text-center text-gray-500 mb-8 text-xs sm:text-sm">
+          상대방도 연장에 동의하면 <br/>
+          대화가 자동으로 다시 시작됩니다.
+        </p>
+
+        {/* 하단 취소 버튼 */}
+        <div className="flex justify-center">
+          <button
+            onClick={onCancel}
+            className="w-full px-4 py-2.5 sm:py-3 rounded-lg text-sm sm:text-base font-medium text-gray-500 bg-gray-50 border border-gray-200 hover:bg-gray-100 transition-colors"
+          >
+            기다리기 취소
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChattingWaitModal;


### PR DESCRIPTION

<img width="524" height="333" alt="스크린샷 2026-02-21 040147" src="https://github.com/user-attachments/assets/1d362070-e4f9-4859-96d1-63e325924c25" />

- 대화 연장 모달 UI 추가

<img width="475" height="369" alt="스크린샷 2026-02-21 040158" src="https://github.com/user-attachments/assets/3e34337b-ea41-41cd-964b-cfe1128940ad" />

- 상대방의 연장 응답 대기 모달

<img width="776" height="390" alt="스크린샷 2026-02-21 040407" src="https://github.com/user-attachments/assets/417db20b-fa97-4f22-9bf7-f3739a1c9869" />

- 연속 3회 메시지 전송 시 입력창 비활성화

<img width="785" height="486" alt="스크린샷 2026-02-21 040423" src="https://github.com/user-attachments/assets/08a8e449-2d26-485d-bbaf-619e2978a96c" />

- 상대방이 메세지 전송시 입력창 활성화

<img width="522" height="465" alt="스크린샷 2026-02-21 040547" src="https://github.com/user-attachments/assets/ef464062-9b2d-45b6-b941-87e7a2e609e7" />

- 대화 종료 시 연장 여부에 따른 모달 분기 처리
- 한 명만 연장 요청 시 종료 모달 표시



- [x] 새로운 기능 추가

## PR Checklist

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)


**++ 테스트를 위해 현재 기본 대화 턴 수 3회로 제한함. 후에 수정 필요**