### PR TITLE
[ faet ] : 커뮤니티 북마크 기능 연동 및 검색바 렌더링 에러 수정

### DIFF
--- a/src/component/community/CommunityDetail.jsx
+++ b/src/component/community/CommunityDetail.jsx
@@ -117,6 +117,23 @@ export default function CommunityDetail() {
     }
   };
 
+  const handleToggleBookmark = async () => {
+  try {
+    const response = await axiosInstance.post(`/api/community/${id}/bookmark/toggle`);
+    const isBookmarked = response.data.data;
+
+    setPost(prev => ({
+      ...prev,
+      isBookmarked: isBookmarked
+    }));
+    
+    alert(isBookmarked ? "즐겨찾기에 등록되었습니다." : "즐겨찾기가 취소되었습니다.");
+    } catch (e) {
+      console.error("즐겨찾기 실패:", e);
+      alert("즐겨찾기 처리에 실패했습니다.");
+    }
+  };
+
   const handleDelete = async () => {
     if (!window.confirm("정말로 삭제하시겠습니까?")) return;
     try {
@@ -242,6 +259,12 @@ export default function CommunityDetail() {
                 count={post.likeCount}
                 active={post.isLiked}
                 onClick={handleToggleLike}
+              />
+              <ActionButton
+                icon={post.isBookmarked ? '🔖' : '📑'}
+                count={post.isBookmarked ? "저장됨" : "저장"}
+                active={post.isBookmarked}
+                onClick={handleToggleBookmark}
               />
               <ActionButton icon="💬" count={comments.length} disabled />
             </div>

--- a/src/component/community/CommunitySearchBar.jsx
+++ b/src/component/community/CommunitySearchBar.jsx
@@ -63,7 +63,7 @@ const CommunitySearchBar = ({ onSearch }) => {
           {/* 드롭다운 메뉴 */}
           {isOpen && (
             <div className="absolute top-full left-0 mt-2 w-full min-w-[120px] bg-white border border-green-50 rounded-2xl shadow-xl z-50 overflow-hidden py-1 animate-in fade-in slide-in-from-top-1">
-              {typeOptions.map((option) => (
+              {options.map((option) => (
                 <button
                   key={option.value}
                   type="button"


### PR DESCRIPTION
## 📝 PR 내용

### 🚀 주요 변경 사항
이번 PR에서는 **커뮤니티 북마크 기능**을 상세 페이지에 실제 연동하고, 팀원 간 협업 과정에서 발생한 **UI 렌더링 에러를 해결**했습니다.

#### 1. 커뮤니티 북마크(Bookmark) 연동 구현
* **API 연동**: 백엔드 북마크 토글 엔드포인트(`/api/community/${id}/bookmark/toggle`)를 연결하여 데이터 정합성을 맞췄습니다.
* **실시간 UI 반영**: `isBookmarked` 상태값에 따라 아이콘(저장/저장됨)과 텍스트가 실시간으로 변경되도록 로직을 추가했습니다.
* **사용자 피드백**: 북마크 처리 성공/실패 시 `alert`를 통해 사용자에게 명확한 알림을 제공합니다.

#### 2. 변수명 동기화 및 버그 수정
* **CommunitySearchBar**: 팀원 작업분과 변수명을 일치시키기 위해 `typeOptions`를 `options`로 수정했습니다.
* **렌더링 버그 해결**: 변수명 불일치로 인해 검색바 드롭다운이 노출되지 않던 문제를 해결하여 정상적인 옵션 선택이 가능하도록 조치했습니다.

### ✅ 테스트 결과
* [x] 상세 페이지에서 북마크 버튼 클릭 시 서버 데이터와 연동되어 UI가 즉각 변경됨
* [x] 북마크 등록/취소 알림창 정상 노출 확인
* [x] 검색바 드롭다운 메뉴가 에러 없이 정상적으로 렌더링됨